### PR TITLE
Fix textarea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 /.bundle/
 /.yardoc
 /Gemfile.lock

--- a/lib/watir_drops/page_object.rb
+++ b/lib/watir_drops/page_object.rb
@@ -51,7 +51,7 @@ module WatirDrops
           when Watir::Button
             watir_element.click
             # TODO - Email & Password types are not set to UserEditable in Watir
-          when Watir::Input
+          when Watir::TextField, Watir::TextArea
             watir_element.wd.clear
             watir_element.send_keys val
           else


### PR DESCRIPTION
Here is a pull for a fix I needed when I used Watir::TextArea in a page object. I am sort of new to contributing to open source, so I may have "too much" in this pull. All you really want is: 
https://github.com/titusfortner/watir_drops/commit/314a28d797bff0ee15486df39fcde4cab8610c09

I verified my update by running "bundle exec rspec -fd spec/watir_drops_spec.rb"  I also edited the test page object (watir_drops/spec/test_page.rb) switched the :name element to a browser.textarea() and ran the spec again. All examples passed for both test runs. 
